### PR TITLE
Resolve user home with a variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ git clone https://github.com/carlosV2/bash-aliases-per-directory.git .bash-alias
 # Bash Aliases Per Directory
 
 # Source the bash dev tools script
-source "~/.bash-aliases-per-directory/run.sh"
+source "$HOME/.bash-aliases-per-directory/run.sh"
 ```
 
 **Enjoy!**


### PR DESCRIPTION
Some configurations are unable to interpret `~` as the user's home:
```
bash: ~/.bash-aliases-per-directory/run.sh: No such file or directory
```

To fix this, we can rely on the `$HOME` variable instead